### PR TITLE
Fixes week label bug in calendar

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -83,8 +83,8 @@ export default function Calendar(props) {
                 year: 'numeric',
                 month: 'long',
               },
-            fixedWeekCount: false,
-            weekNumbers: false
+              fixedWeekCount: false,
+              weekNumbers: false
             },
             timeGridWeek: {
               titleFormat: {

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -83,6 +83,8 @@ export default function Calendar(props) {
                 year: 'numeric',
                 month: 'long',
               },
+            fixedWeekCount: false,
+            weekNumbers: false
             },
             timeGridWeek: {
               titleFormat: {


### PR DESCRIPTION
#### Overview

Week labels were removed for the month view so that they aren't overlapping each other

#### Merger

- @amgoodfellow 